### PR TITLE
Update admin_urls.py

### DIFF
--- a/django_inlines/admin_urls.py
+++ b/django_inlines/admin_urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls.defaults import *
+except:
+    from django.conf.urls import *
 
 
 urlpatterns = patterns('django_inlines.views',


### PR DESCRIPTION
Fix for Django 1.4+ (deprecated in 1.4, error in 1.6)
